### PR TITLE
Add select action, rework play/discard/move cards

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,5 +1,4 @@
 use crate::card::Card;
-use crate::hand::SelectHand;
 use crate::joker::Jokers;
 use crate::stage::Blind;
 use pyo3::pyclass;
@@ -30,9 +29,10 @@ impl fmt::Display for MoveDirection {
 #[cfg_attr(feature = "python", pyclass(eq))]
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Action {
-    Play(SelectHand),
-    Discard(SelectHand),
-    MoveCard(MoveDirection, Card),
+    SelectCard(Card),
+    MoveCard(MoveDirection),
+    Play(),
+    Discard(),
     CashOut(usize),
     BuyJoker(Jokers),
     NextRound(),
@@ -43,14 +43,17 @@ pub enum Action {
 impl fmt::Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Play(cards) => {
-                write!(f, "Play: {:?}", cards)
+            Self::SelectCard(card) => {
+                write!(f, "SelectCard: {:?}", card)
             }
-            Self::Discard(cards) => {
-                write!(f, "Discard: {:?}", cards)
+            Self::Play() => {
+                write!(f, "Play")
             }
-            Self::MoveCard(dir, card) => {
-                write!(f, "MoveCard: {:?} - {:}", card, dir)
+            Self::Discard() => {
+                write!(f, "Discard")
+            }
+            Self::MoveCard(dir) => {
+                write!(f, "MoveCard: {:}", dir)
             }
             Self::CashOut(reward) => {
                 write!(f, "CashOut: {:}", reward)

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -15,6 +15,7 @@ const DEFAULT_BASE_SCORE: usize = 0;
 const DEFAULT_ANTE_START: usize = 1;
 const DEFAULT_ANTE_END: usize = 8;
 const DEFAULT_JOKER_SLOTS: usize = 5;
+const DEFAULT_SELECTED_MAX: usize = 5;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "python", pyclass)]
@@ -35,6 +36,7 @@ pub struct Config {
     pub ante_start: usize,
     pub ante_end: usize,
     pub joker_slots: usize,
+    pub selected_max: usize,
 }
 
 impl Config {
@@ -55,6 +57,7 @@ impl Config {
             ante_start: DEFAULT_ANTE_START,
             ante_end: DEFAULT_ANTE_END,
             joker_slots: DEFAULT_JOKER_SLOTS,
+            selected_max: DEFAULT_SELECTED_MAX,
         };
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -24,7 +24,7 @@ pub enum GameError {
     InvalidStage,
     #[error("Invalid action")]
     InvalidAction,
-    #[error("No card match")]
+    #[error("No blind match")]
     InvalidBlind,
     #[error("No card match")]
     NoCardMatch,
@@ -36,6 +36,10 @@ pub enum GameError {
     NoAvailableSlot,
     #[error("Invalid balance")]
     InvalidBalance,
+    #[error("Invalid move card")]
+    InvalidMoveCard,
+    #[error("Invalid select card")]
+    InvalidSelectCard,
 }
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
While considering how to write accurate action space for this game, I realized it is not feasible to have the currently unbound (infinite) action space. Despite Balatro theoretically having infinite actions, for the sake of training agents, it make sense to apply some constraints and bound the potential action space. For that reason, I've decided to change the interface for playing and discarding cards.

Previously the `Play` and `Discard` actions took a `Vec<Card>`. Now, there is a separate action `SelectCard` that essentially "highlights" a card, similar to actually playing balatro. Up to 5 cards can be select, and then either played or discarded. 

This does reduce the potential action space, since instead of a seperate `Play` and `Discard` for each combination of available cards, there is one `Select` action per available card and 1 `Play` and 1 `Discard` action.

This doesn't constrain the game, as there could still theoretically be an infinite amount of available cards. But future changes will constrain that. 